### PR TITLE
Replacing some 'print' statements with logging.info

### DIFF
--- a/ballistics.py
+++ b/ballistics.py
@@ -8,8 +8,11 @@ import utils
 from holdover import holdover
 from points import points
 
+import logging
 
 def solve(drag_function, drag_coefficient, vi, sight_height, shooting_angle, zero_angle, wind_speed, wind_angle):
+
+    logger = logging.getLogger()
 
     t = 0
     dt = 0
@@ -62,15 +65,19 @@ def solve(drag_function, drag_coefficient, vi, sight_height, shooting_angle, zer
 
             if x > 0:
                 range_yards = round(x/3)
-                print("range_yards {}".format(range_yards))
+#                print("range_yards {}".format(range_yards))
+                logger.info("range_yards {}".format(range_yards))
                 # if range_yards == 400:
                 moa_correction = -angles.rad_to_moa(math.atan(y / x))
-                print("moa_correction {}". format(moa_correction))
+#                print("moa_correction {}". format(moa_correction))
+                logger.info("moa_correction {}". format(moa_correction))
                 path_inches = y*12
-                print("path_inches {}". format(path_inches))
+#                print("path_inches {}". format(path_inches))
+                logger.info("path_inches {}". format(path_inches))
                 impact_in = utils.moaToInch(moa_correction, x)
                 seconds = t+dt
-                print("seconds {}". format(seconds))
+#                print("seconds {}". format(seconds))
+                logger.info("seconds {}". format(seconds))
                 hold_overs.add_point(
                     holdover(range_yards, moa_correction, impact_in, path_inches, seconds))
 

--- a/bdc.py
+++ b/bdc.py
@@ -1,9 +1,13 @@
 import atmosphere
 import angles
 import ballistics
+import logging
 
 
 def calcBDC(range):
+
+    logger = logging.getLogger()
+
     k = 0
     # The ballistic coefficient for the projectile.
     bc = 0.269
@@ -34,7 +38,8 @@ def calcBDC(range):
     bc = atmosphere.atmosphere_correction(
         bc, altitude, barometer, temperature, relative_humidity)
 
-    print("bc {}".format(bc))
+    logger.info("bc {}".format(bc))
+    # print("bc {}".format(bc))
 
     # First find the angle of the bore relative to the sighting system.
     # We call this the "zero angle", since it is the angle required to

--- a/example.py
+++ b/example.py
@@ -6,15 +6,20 @@ import math
 import sys, logging
 
 #logLevel=logging.DEBUG
-logLevel=logging.INFO
+#logLevel=logging.INFO
 #logLevel=logging.WARNING
-#logLevel=logging.CRITICAL
 
-logging.basicConfig(format='%(levelname)s : %(filename)s : %(funcName)s : %(lineno)4d : %(message)s', level=logLevel, handlers=[logging.StreamHandler(sys.stdout)])
+# If logLevel is unset, we will only display the most serious messages.
+try:
+    logLevel
+except NameError:
+    logLevel=logging.CRITICAL
+finally:
+    logging.basicConfig(format='%(levelname)s : %(filename)s : %(funcName)s : %(lineno)4d : %(message)s', level=logLevel, handlers=[logging.StreamHandler(sys.stdout)])
 
+logging.debug('Example Debug Message')
+logging.info('Example Info Message')
 logging.warning('Example Warning Message')
-
-logging.debug('Log Test Message')
 
 hold_overs = calcBDC(400)
 

--- a/example.py
+++ b/example.py
@@ -10,7 +10,7 @@ logLevel=logging.INFO
 #logLevel=logging.WARNING
 #logLevel=logging.CRITICAL
 
-logging.basicConfig(format='%(levelname)s: %(message)s', level=logLevel, handlers=[logging.StreamHandler(sys.stdout)])
+logging.basicConfig(format='%(levelname)s : %(filename)s : %(funcName)s : %(lineno)4d : %(message)s', level=logLevel, handlers=[logging.StreamHandler(sys.stdout)])
 
 logging.warning('Example Warning Message')
 

--- a/example.py
+++ b/example.py
@@ -6,7 +6,7 @@ import math
 import sys, logging
 
 #logLevel=logging.DEBUG
-#logLevel=logging.INFO
+logLevel=logging.INFO
 #logLevel=logging.WARNING
 
 # If logLevel is unset, we will only display the most serious messages.

--- a/example.py
+++ b/example.py
@@ -3,6 +3,19 @@ from utils import get_incline_compensation
 from utils import get_cant_compensation
 import math
 
+import sys, logging
+
+#logLevel=logging.DEBUG
+logLevel=logging.INFO
+#logLevel=logging.WARNING
+#logLevel=logging.CRITICAL
+
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logLevel, handlers=[logging.StreamHandler(sys.stdout)])
+
+logging.warning('Example Warning Message')
+
+logging.debug('Log Test Message')
+
 hold_overs = calcBDC(400)
 
 for point in hold_overs.points:


### PR DESCRIPTION
Hello,
Just seeing how I can using pyBallistics and I ran into a small issue.   In a few places, the using of print statements flood the screen with status updates.  I understand these can be useful when developing the code but they're just an eyesore for general use.  I was able to add support for python's logging module in a couple places and a few lines to the example.py file to allow the user to display as much or as little as they want.  

What do you think?  Does this help or is there something I'm not seeing?

Thanks,
Dave