### PR TITLE
Addmetricrange

### DIFF
--- a/ballistics.py
+++ b/ballistics.py
@@ -9,7 +9,7 @@ import utils
 from holdover import holdover
 from points import points
 
-def solve(drag_function, drag_coefficient, vi, sight_height, shooting_angle, zero_angle, wind_speed, wind_angle):
+def solve(range_max, drag_function, drag_coefficient, vi, sight_height, shooting_angle, zero_angle, wind_speed, wind_angle):
 
     t = 0
     dt = 0
@@ -25,7 +25,8 @@ def solve(drag_function, drag_coefficient, vi, sight_height, shooting_angle, zer
     y = 0
 
     # Convert BALLISTICS_COMPUTATION_MAX_YARDS to feet
-    r = math.floor(constants.BALLISTICS_COMPUTATION_MAX_YARDS*3)
+#    r = math.floor(constants.BALLISTICS_COMPUTATION_MAX_YARDS*3)
+    r = math.floor((range_max+1)*3)
 
     step_feet = [*range(1, r, 1)]
     step_meters = [*np.arange(0.8202, r, 0.8202)]

--- a/bdc.py
+++ b/bdc.py
@@ -14,7 +14,11 @@ def calcBDC(range):
     # The shooting angle (uphill / downhill), in degrees.
     angle = 0
     # The zero range of the rifle, in yards.
-    zero = 50
+#    zero = 50
+#    zero = 100
+    zero = 200
+#    zero_unit = 'm'
+    zero_unit = 'y'
     # The wind speed in miles per hour.
     windspeed = 0
     # The wind angle (0=headwind, 90=right to left, 180=tailwind, 270/-90=left to right)
@@ -39,6 +43,11 @@ def calcBDC(range):
         bc, altitude, barometer, temperature, relative_humidity)
 
     print("bc {}".format(bc))
+
+    # Convert zero range in meters to yards for calculating the zero angle
+    if zero_unit.lower() == 'm':
+#        zero = zero*1.093613
+        zero = zero*((100/2.54)/36)
 
     # First find the angle of the bore relative to the sighting system.
     # We call this the "zero angle", since it is the angle required to

--- a/bdc.py
+++ b/bdc.py
@@ -1,24 +1,12 @@
 import atmosphere
 import angles
 import ballistics
+import constants
 
 
-def calcBDC(range):
+def calcBDC(range_max = constants.BALLISTICS_COMPUTATION_MAX_YARDS, bc = 0.269, v = 3165, sh = 1.5, angle = 0,
+            zero_dist = 50, zero_unit = 'y', drag_function = "G1"):
     k = 0
-    # The ballistic coefficient for the projectile.
-    bc = 0.269
-    # Intial velocity, in ft/s
-    v = 3165
-    # The Sight height over bore, in inches.
-    sh = 1.5
-    # The shooting angle (uphill / downhill), in degrees.
-    angle = 0
-    # The zero range of the rifle, in yards.
-#    zero = 50
-#    zero = 100
-    zero = 200
-#    zero_unit = 'm'
-    zero_unit = 'y'
     # The wind speed in miles per hour.
     windspeed = 0
     # The wind angle (0=headwind, 90=right to left, 180=tailwind, 270/-90=left to right)
@@ -33,8 +21,6 @@ def calcBDC(range):
     temperature = 59
     relative_humidity = 0.7
 
-    drag_function = "G1"
-
     # If we wish to use the weather correction features, we need to
     # Correct the BC for any weather conditions.  If we want standard conditions,
     # then we can just leave this commented out.
@@ -46,8 +32,8 @@ def calcBDC(range):
 
     # Convert zero range in meters to yards for calculating the zero angle
     if zero_unit.lower() == 'm':
-#        zero = zero*1.093613
-        zero = zero*((100/2.54)/36)
+#        zero_dist = zero_dist*1.093613
+        zero_dist = zero_dist*((100/2.54)/36)
 
     # First find the angle of the bore relative to the sighting system.
     # We call this the "zero angle", since it is the angle required to
@@ -55,12 +41,12 @@ def calcBDC(range):
     # to us, but is required for making a full ballistic solution.
     # It is left here to allow for zero-ing at altitudes (bc) different from the
     # final solution, or to allow for zero's other than 0" (ex: 3" high at 100 yds)
-    zeroangle = angles.zero_angle(drag_function, bc, v, sh, zero, 0)
+    zeroangle = angles.zero_angle(drag_function, bc, v, sh, zero_dist, 0)
 
     # Now we have everything needed to generate a full solution.
     # So we do.  The solution is stored in the pointer "sln" passed as the last argument.
     # k has the number of yards the solution is valid for, also the number of rows in the solution.
-    hold_overs = ballistics.solve(drag_function, bc, v, sh, angle,
+    hold_overs = ballistics.solve(range_max, drag_function, bc, v, sh, angle,
                                   zeroangle, windspeed, windangle)
 
     return hold_overs

--- a/bdc.py
+++ b/bdc.py
@@ -20,6 +20,10 @@ def calcBDC(range):
     # The wind angle (0=headwind, 90=right to left, 180=tailwind, 270/-90=left to right)
     windangle = 0
 
+    # Numbers for 22lr CCI Standard Velocity
+#    bc = 0.122
+#    v = 1070
+
     altitude = 0
     barometer = 29.59
     temperature = 59

--- a/example.py
+++ b/example.py
@@ -3,7 +3,10 @@ from utils import get_incline_compensation
 from utils import get_cant_compensation
 import math
 
-hold_overs = calcBDC(400)
+#hold_overs = calcBDC(400)
+#hold_overs = calcBDC(range = 400, zero_unit = "m")
+#hold_overs = calcBDC(zero_unit = "m", range = 400)
+hold_overs = calcBDC()
 
 print()
 print("All Points in hold_overs:")

--- a/example.py
+++ b/example.py
@@ -5,10 +5,44 @@ import math
 
 hold_overs = calcBDC(400)
 
+print()
+print("All Points in hold_overs:")
 for point in hold_overs.points:
     incline_compensation = get_incline_compensation(point.path_inches, -15)
 
     cant_compensation = get_cant_compensation(point.seconds, 90, 1.5)
 
-    print("hold_over %s %s %s %s %s" %
-          (point.yards, point.path_inches, incline_compensation, abs(point.path_inches-incline_compensation), cant_compensation))
+    print("hold_over %8s %8s %s %s %s %s" %
+          (point.yards, point.meters, point.path_inches, incline_compensation, abs(point.path_inches-incline_compensation), cant_compensation))
+
+print()
+print("Whole Yards Only")
+print("%-8s | %-8s  | %-8s | %-8s | %-9s | %-8s |" %
+      ("Range", "Drop", "MOA", "Mils", "Time", "Velocity"))
+print("%-8s | %-8s  | %-8s | %-8s | %-9s | %-8s |" %
+      ("(Yards)", "(Inches)", "", "", "(Seconds)", "(fps)"))
+for point in hold_overs.points:
+    if float(point.yards).is_integer():
+        pi = '{:.3f}'.format(round(point.path_inches, 3))
+        moac = '{:.2f}'.format(round(point.moa_correction, 2))
+        milc = '{:.2f}'.format(round(point.mil_correction, 2))
+        stime = '{:.3f}'.format(round(point.seconds, 3))
+        vel = '{:.2f}'.format(round(point.velocity, 2))
+        print("%8s | %8s  | %8s | %8s | %9s | %8s |" %
+              (point.yards, pi, moac, milc, stime, vel))
+
+print()
+print("Whole Meters Only")
+print("%-8s | %-8s  | %-8s | %-8s | %-9s | %-8s |" %
+      ("Range", "Drop", "MOA", "Mils", "Time", "Velocity"))
+print("%-8s | %-8s  | %-8s | %-8s | %-9s | %-8s |" %
+      ("(Meters)", "(Inches)", "", "", "(Seconds)", "(fps)"))
+for point in hold_overs.points:
+    if float(point.meters).is_integer():
+        pi = '{:.3f}'.format(round(point.path_inches, 3))
+        moac = '{:.2f}'.format(round(point.moa_correction, 2))
+        milc = '{:.2f}'.format(round(point.mil_correction, 2))
+        stime = '{:.3f}'.format(round(point.seconds, 3))
+        vel = '{:.2f}'.format(round(point.velocity, 2))
+        print("%8s | %8s  | %8s | %8s | %9s | %8s |" %
+              (point.meters, pi, moac, milc, stime, vel))

--- a/holdover.py
+++ b/holdover.py
@@ -1,5 +1,5 @@
 class holdover:
-    def __init__(self, yards, meters, moa_correction, mil_correction, impact_in, path_inches, seconds):
+    def __init__(self, yards, meters, moa_correction, mil_correction, impact_in, path_inches, seconds, velocity):
         self.yards = yards
         self.meters = meters
         self.moa_correction = moa_correction
@@ -7,6 +7,7 @@ class holdover:
         self.impact_in = impact_in
         self.path_inches = path_inches
         self.seconds = seconds
+        self.velocity = velocity
 
     def get_meters(self):
         return self.meters

--- a/holdover.py
+++ b/holdover.py
@@ -1,5 +1,5 @@
 class holdover:
-    def __init__(self, yards, moa_correction, impact_in, path_inches, seconds):
+    def __init__(self, yards, meters, moa_correction, mil_correction, impact_in, path_inches, seconds):
         self.yards = yards
         self.meters = meters
         self.moa_correction = moa_correction

--- a/holdover.py
+++ b/holdover.py
@@ -1,13 +1,21 @@
 class holdover:
     def __init__(self, yards, moa_correction, impact_in, path_inches, seconds):
         self.yards = yards
+        self.meters = meters
         self.moa_correction = moa_correction
+        self.mil_correction = mil_correction
         self.impact_in = impact_in
         self.path_inches = path_inches
         self.seconds = seconds
 
+    def get_meters(self):
+        return self.meters
+
     def get_yards(self):
         return self.yards
+
+    def get_mil_correction(self):
+        return self.mil_correction
 
     def get_moa_correction(self):
         return self.moa_correction


### PR DESCRIPTION
- Added support for calculating ranges in meters and yards at the same time.  
- Added examples for displaying the results in meters, yards or both.
- Expanded holdover to allow a few more items to be passed.

When we're calculating ballistics for a user, we do not know what range they are shooting on, therefore we cannot know how it is measured.  These fixes will allow for the use of pyBallistics for both ways of commonly measuring ranges. 

This patch is not 100% complete.  It still requires a patch to the zero_angle function to allow for ranges in either meters or yards.  However I did not want to overwhelm you with too big a pull request and this was already pushing the boundaries of what is acceptable.  However if you do accept this, it should be fairly easy to make the other changes.

What do you think?

Dave
